### PR TITLE
Revert "add a new mode days-interval"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ dist: trusty
 sudo: required
 addons:
   chrome: stable  # run the tests with Chrome headless
+before_install:
+- export TZ=Europe/Paris  # run the test in our timezone, which is more tricky than UTC

--- a/src/dateutils.js
+++ b/src/dateutils.js
@@ -13,7 +13,7 @@ export function formatHour (hour, minutes = 0) {
 
 export function getTzOffset (datetime) {
   const offset = (datetime || moment()).utcOffset()
-  const sign = offset <= 0 ? '-' : '+'
+  const sign = offset >= 0 ? '+' : '-'
   const hours = Math.ceil(Math.abs(offset) / 60)
   const minutes = Math.abs(offset) % 60
   return `${sign}${formatHour(hours, minutes)}`

--- a/src/dateutils.js
+++ b/src/dateutils.js
@@ -11,9 +11,9 @@ export function formatHour (hour, minutes = 0) {
   return padStart(`${hour}`, 2, '0') + ':' + padStart(`${minutes}`, 2, '0')
 }
 
-export function getTzOffset () {
-  const offset = new Date().getTimezoneOffset()
-  const sign = offset <= 0 ? '+' : '-'
+export function getTzOffset (datetime) {
+  const offset = (datetime || moment()).utcOffset()
+  const sign = offset <= 0 ? '-' : '+'
   const hours = Math.ceil(Math.abs(offset) / 60)
   const minutes = Math.abs(offset) % 60
   return `${sign}${formatHour(hours, minutes)}`

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ function enumerateDaysOfCalendar (currentDay, format = 'D') {
 
 
 function tableForDay (day, nowButtonText) {
+  day = day || moment()
   return tableTemplate({
     styles: styles,
     thead: dayHeaderTemplate({
@@ -156,21 +157,9 @@ export function init (
   if (initValue) {
     selectedDay = moment(initValue)
     inputField.value = selectedDay.format(format)
-  } else {
-    const today = moment()
-    selectedDay = moment({
-      year: today.year(),
-      month: today.month(),
-      date: 1,
-      hours: 0,
-      minutes: 0,
-      seconds: 0,
-      milliseconds: 0,
-    })
   }
 
   function dispatchUpdateEvent () {
-    if (!selectedDay) return // do not bother if no value yet
     const data = {
       id: id,
       format: format,
@@ -210,6 +199,7 @@ export function init (
   }
 
   function nextInputValue () {
+    if (!selectedDay) return ''
     if (utcMode) {
       return selectedDay.format(format)
     } else {
@@ -256,6 +246,7 @@ export function init (
           mainTable.innerHTML = tableForDay(selectedDay, nowButtonText)
         } else if (t.classList.contains(styles.dow)) {
           const clickedDay = moment(utils.getDataValue(t))
+          selectedDay = selectedDay || moment()
           selectedDay.set({
             'year': clickedDay.year(),
             'month': clickedDay.month(),
@@ -311,12 +302,15 @@ export function init (
 
   inputField.addEventListener('change', function (e) {
     let newDay = null
-    if (utcMode) {
-      newDay = moment.utc(inputField.value)
-    } else {
-      newDay = moment(inputField.value)
+    if (inputField.value) {
+      if (utcMode) {
+        newDay = moment.utc(inputField.value)
+      } else {
+        newDay = moment(inputField.value)
+      }
     }
-    if (newDay.isValid()) {
+    if (newDay == null || newDay.isValid()) {
+      // newDay = null => the user wants to reset the field
       selectedDay = newDay
       updateValue()
       hideAndResetTable()

--- a/src/index.js
+++ b/src/index.js
@@ -187,13 +187,18 @@ export function init (
   function switchTzField (forceUtc, doUpdate = true) {
     const isForced = typeof forceUtc !== 'undefined'
     if ((isForced && forceUtc === true) || (!isForced && tzField.innerHTML !== 'UTC')) {
-      tzField.innerHTML = 'UTC'
       utcMode = true
     } else {
-      tzField.innerHTML = `UTC${dateutils.getTzOffset(selectedDay)}`
       utcMode = false
     }
+    updateTzFieldHTML(utcMode)
+    inputField.value = nextInputValue() // put the inputField value in the correct TZ
     if (doUpdate) dispatchUpdateEvent()
+  }
+
+  function updateTzFieldHTML (utcMode) {
+    const offset = utcMode ? '' : dateutils.getTzOffset(selectedDay)
+    tzField.innerHTML = `UTC${offset}`
   }
 
   function padSelectedDay () {
@@ -215,6 +220,10 @@ export function init (
   function updateValue () {
     dispatchUpdateEvent()
     inputField.value = nextInputValue()
+    if (tzField && !utcMode) {
+      // update the offset based on the selected date
+      updateTzFieldHTML(utcMode)
+    }
   }
 
   function hideAndResetTable () {

--- a/src/index.js
+++ b/src/index.js
@@ -180,7 +180,7 @@ export function init (
     if (callback) {
       callback(data)
     }
-    const event = new CustomEvent('bluepicker:update', data)
+    const event = new CustomEvent('bluepicker:update', {detail: data})
     root.dispatchEvent(event)
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -190,7 +190,7 @@ export function init (
       tzField.innerHTML = 'UTC'
       utcMode = true
     } else {
-      tzField.innerHTML = `UTC${dateutils.getTzOffset()}`
+      tzField.innerHTML = `UTC${dateutils.getTzOffset(selectedDay)}`
       utcMode = false
     }
     if (doUpdate) dispatchUpdateEvent()

--- a/src/index.tests.js
+++ b/src/index.tests.js
@@ -22,6 +22,26 @@ function clickInputAndAssertDropdownIsVisible () {
   expect(dropdown.style.display).toBe('block')
 }
 
+
+describe('Bluepicker mode days', () => {
+  afterEach(function () {
+    document.body.removeChild(document.getElementById('root'))
+  })
+  it('should propagate via callback', (done) => {
+    const date = '2012-03-03T22:45:32'
+    function callback (detail) {
+      expect(detail.value.format('YYYY-MM-DDTHH:mm:ss')).toBe(date)
+      delete detail['value']
+      expect(detail).toEqual({id: 'root', format: '', utcMode: false})
+      done()
+    }
+    setUpBluePicker({mode: 'days', callback: callback})
+    const inputElt = document.querySelector('#root > input')
+    inputElt.value = date
+    dispatchEvent(inputElt, 'change')
+  })
+})
+
 describe('Bluepicker mode days', () => {
   beforeEach(function () {
     setUpBluePicker({mode: 'days'})
@@ -32,6 +52,20 @@ describe('Bluepicker mode days', () => {
   it('should not display the table at init', () => {
     const dropdown = document.querySelector(`.${styles.bluepicker_date_dropdown}`)
     expect(dropdown.style.display).toBe('none')
+  })
+  it('should propagate via custom event', (done) => {
+    const inputElt = document.querySelector('#root > input')
+    const date = '2012-03-03T22:45:32'
+    const root = document.querySelector('#root')
+    let listener = null
+    listener = (e) => {
+      expect(e.detail).toEqual({value: moment(date), id: 'root', format: '', utcMode: false})
+      root.removeEventListener('bluepicker:update', listener)
+      done()
+    }
+    root.addEventListener('bluepicker:update', listener)
+    inputElt.value = date
+    dispatchEvent(inputElt, 'change')
   })
   it('should allow the selection of a day', () => {
     clickInputAndAssertDropdownIsVisible()

--- a/src/index.tests.js
+++ b/src/index.tests.js
@@ -67,7 +67,7 @@ describe('Bluepicker mode days', () => {
     inputElt.value = date
     dispatchEvent(inputElt, 'change')
   })
-  it('should allow the selection of a day', () => {
+  it('should allow the selection of a day and its manual reset', (done) => {
     clickInputAndAssertDropdownIsVisible()
     const allDatesElts = Array.from(document.querySelectorAll(`.${styles.dow}`))
     const firstDateElt = allDatesElts.filter((el) => el.textContent === '15')[0]
@@ -76,6 +76,19 @@ describe('Bluepicker mode days', () => {
     const yearAndMonth = moment().format('YYYY-MM')
     const offset = getTzOffset(moment(`${yearAndMonth}-15`))
     expect(inputElt.value).toEqual(`${yearAndMonth}-15T00:00:00${offset}`)
+
+    // try to reset it and check that the event is sent upstream
+    const root = document.querySelector('#root')
+    let listener = null
+    listener = (e) => {
+      expect(e.detail.value).toBe(null)
+      root.removeEventListener('bluepicker:update', listener)
+      done()
+    }
+    root.addEventListener('bluepicker:update', listener)
+    inputElt.value = ''
+    dispatchEvent(inputElt, 'change')
+    expect(inputElt.value).toEqual('')
   })
 })
 

--- a/src/index.tests.js
+++ b/src/index.tests.js
@@ -29,18 +29,18 @@ describe('Bluepicker mode days', () => {
   afterEach(function () {
     document.body.removeChild(document.getElementById('root'))
   })
-  it('It should not display the table at init', () => {
+  it('should not display the table at init', () => {
     const dropdown = document.querySelector(`.${styles.bluepicker_date_dropdown}`)
     expect(dropdown.style.display).toBe('none')
   })
-  it('It should allow the selection of a day', () => {
+  it('should allow the selection of a day', () => {
     clickInputAndAssertDropdownIsVisible()
     const allDatesElts = Array.from(document.querySelectorAll(`.${styles.dow}`))
     const firstDateElt = allDatesElts.filter((el) => el.textContent === '15')[0]
     firstDateElt.click()
     const inputElt = document.querySelector('#root > input')
     const yearAndMonth = moment().format('YYYY-MM')
-    const offset = getTzOffset()
+    const offset = getTzOffset(moment(`${yearAndMonth}-15`))
     expect(inputElt.value).toEqual(`${yearAndMonth}-15T00:00:00${offset}`)
   })
 })
@@ -52,11 +52,11 @@ describe('Bluepicker mode hours', () => {
   afterEach(function () {
     document.body.removeChild(document.getElementById('root'))
   })
-  it('It should not display the table at init', () => {
+  it('should not display the table at init', () => {
     const dropdown = document.querySelector(`.${styles.bluepicker_date_dropdown}`)
     expect(dropdown.style.display).toBe('none')
   })
-  it('It should allow the selection of a day and an hour', () => {
+  it('should allow the selection of a day and an hour', () => {
     clickInputAndAssertDropdownIsVisible()
     const allDatesElts = Array.from(document.querySelectorAll(`.${styles.dow}`))
     const firstDateElt = allDatesElts.filter((el) => el.textContent === '15')[0]
@@ -69,7 +69,7 @@ describe('Bluepicker mode hours', () => {
     allHoursElts[2].click()
     const inputElt = document.querySelector('#root > input')
     const yearAndMonth = moment().format('YYYY-MM')
-    const offset = getTzOffset()
+    const offset = getTzOffset(moment(`${yearAndMonth}-15`))
     expect(inputElt.value).toEqual(`${yearAndMonth}-15T02:00:00${offset}`)
   })
 })
@@ -81,11 +81,11 @@ describe('Bluepicker mode minutes', () => {
   afterEach(function () {
     document.body.removeChild(document.getElementById('root'))
   })
-  it('It should not display the table at init', () => {
+  it('should not display the table at init', () => {
     const dropdown = document.querySelector(`.${styles.bluepicker_date_dropdown}`)
     expect(dropdown.style.display).toBe('none')
   })
-  it('It should allow the selection of a day an hour and minutes', () => {
+  it('should allow the selection of a day an hour and minutes', () => {
     clickInputAndAssertDropdownIsVisible()
     const allDatesElts = Array.from(document.querySelectorAll(`.${styles.dow}`))
     const firstDateElt = allDatesElts.filter((el) => el.textContent === '15')[0]
@@ -102,12 +102,12 @@ describe('Bluepicker mode minutes', () => {
     allMinutesElts[0].click()
     const inputElt = document.querySelector('#root > input')
     const yearAndMonth = moment().format('YYYY-MM')
-    const offset = getTzOffset()
+    const offset = getTzOffset(moment(`${yearAndMonth}-15`))
     expect(inputElt.value).toEqual(`${yearAndMonth}-15T23:00:00${offset}`)
   })
-  it('It should not change the hour set manually by the user', () => {
+  it('should not change the hour set manually by the user', () => {
     clickInputAndAssertDropdownIsVisible()
-    const offset = getTzOffset()
+    const offset = getTzOffset(moment('2012-03-03T22:45:32'))
     const inputElt = document.querySelector('#root > input')
     inputElt.value = `2012-03-03T22:45:32${offset}`
     dispatchEvent(inputElt, 'change')

--- a/src/index.tests.js
+++ b/src/index.tests.js
@@ -22,50 +22,6 @@ function clickInputAndAssertDropdownIsVisible () {
   expect(dropdown.style.display).toBe('block')
 }
 
-describe('Bluepicker mode days-interval', () => {
-  beforeEach(function () {
-    setUpBluePicker({mode: 'days-interval'})
-  })
-  afterEach(function () {
-    document.body.removeChild(document.getElementById('root'))
-  })
-  it('It should not display the table at init', () => {
-    const dropdown = document.querySelector(`.${styles.bluepicker_date_dropdown}`)
-    expect(dropdown.style.display).toBe('none')
-  })
-  it('It should allow the selection of a date interval in days-interval mode (basic)', () => {
-    clickInputAndAssertDropdownIsVisible()
-    const allDatesElts = Array.from(document.querySelectorAll(`.${styles.dow}`))
-    const firstDateElt = allDatesElts.filter((el) => el.textContent === '15')[0]
-    const secondDateElt = allDatesElts.filter((el) => el.textContent === '19')[0]
-    firstDateElt.click()
-    dispatchEvent(secondDateElt, 'mouseover')
-    const highlightedText = Array.from(document.querySelectorAll(`.${styles.selectedInterval}`)).map((el) => el.textContent)
-    expect(highlightedText).toEqual(['15', '16', '17', '18', '19'])
-  })
-  it('It should allow the selection of a date interval in days-interval mode (reverse)', () => {
-    clickInputAndAssertDropdownIsVisible()
-    const allDatesElts = Array.from(document.querySelectorAll(`.${styles.dow}`))
-    const firstDateElt = allDatesElts.filter((el) => el.textContent === '19')[0]
-    const secondDateElt = allDatesElts.filter((el) => el.textContent === '15')[0]
-    firstDateElt.click()
-    dispatchEvent(secondDateElt, 'mouseover')
-    const highlightedText = Array.from(document.querySelectorAll(`.${styles.selectedInterval}`)).map((el) => el.textContent)
-    expect(highlightedText).toEqual(['15', '16', '17', '18', '19'])
-  })
-  it('It should set the input value to a correct date interval', () => {
-    clickInputAndAssertDropdownIsVisible()
-    const allDatesElts = Array.from(document.querySelectorAll(`.${styles.dow}`))
-    const firstDateElt = allDatesElts.filter((el) => el.textContent === '19')[0]
-    const secondDateElt = allDatesElts.filter((el) => el.textContent === '15')[0]
-    firstDateElt.click()
-    secondDateElt.click()
-    const inputElt = document.querySelector('#root > input')
-    const yearAndMonth = moment().format('YYYY-MM')
-    expect(inputElt.value).toEqual(`${yearAndMonth}-15/${yearAndMonth}-19`)
-  })
-})
-
 describe('Bluepicker mode days', () => {
   beforeEach(function () {
     setUpBluePicker({mode: 'days'})

--- a/src/styles.css
+++ b/src/styles.css
@@ -45,10 +45,6 @@
   }
 }
 
-:local(.selectedInterval) {
-  background-color: #eee;
-}
-
 :local(.nowButton) {
   padding: 5px 2px;
 }


### PR DESCRIPTION
This PR contains several unrelated commits:

1. revert my mode days-interval : I won't be using it for now so better keep bluepicker simple and not include a functionality used nowhere

2. update tz field based on input value

3. fix the custom event dispatch (it was broken)

4. allow a user to clear the input field to unset the date he has previously chosen.